### PR TITLE
Allow versioned types conditions in exports

### DIFF
--- a/.changeset/loose-ducks-cross.md
+++ b/.changeset/loose-ducks-cross.md
@@ -1,0 +1,5 @@
+---
+'publint': patch
+---
+
+Allow versioned types conditions (e.g. `"types@>=5.2"`) in `"exports"` when checking for `"types"` condition ordering

--- a/packages/publint/src/shared/core.js
+++ b/packages/publint/src/shared/core.js
@@ -820,10 +820,19 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
         // check preceding conditions before the `types` condition, if there are nested
         // conditions, check if they also have the `types` condition. If they do, there's
         // a good chance those take precedence over this non-first `types` condition, which
-        // is fine and is usually used as fallback instead.
+        // is fine and is usually used as fallback instead. Versioned `types` conditions
+        // are allowed to precede the `types` condition.
         const precedingKeys = exportsKeys
           .slice(0, exportsKeys.indexOf('types'))
           .filter((key) => !key.startsWith('types'))
+
+        // TODO: check that versioned types are valid and the ranges don't overlap.
+
+        // TODO: check the order of the conditions are correct. For example,
+        //  1. Nested conditions
+        //  2. Versioned `types` conditions
+        //  3. `types` condition
+        //  4. All other conditions
 
         let isPrecededByNestedTypesCondition = false
         for (const key of precedingKeys) {

--- a/packages/publint/src/shared/core.js
+++ b/packages/publint/src/shared/core.js
@@ -819,9 +819,12 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
       if ('types' in exportsValue && exportsKeys[0] !== 'types') {
         // check preceding conditions before the `types` condition, if there are nested
         // conditions, check if they also have the `types` condition. If they do, there's
-        // a good chance those take precendence over this non-first `types` condition, which
+        // a good chance those take precedence over this non-first `types` condition, which
         // is fine and is usually used as fallback instead.
-        const precedingKeys = exportsKeys.slice(0, exportsKeys.indexOf('types'))
+        const precedingKeys = exportsKeys
+          .slice(0, exportsKeys.indexOf('types'))
+          .filter((key) => !key.startsWith('types'))
+
         let isPrecededByNestedTypesCondition = false
         for (const key of precedingKeys) {
           if (
@@ -832,7 +835,7 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
             break
           }
         }
-        if (!isPrecededByNestedTypesCondition) {
+        if (precedingKeys.length > 0 && !isPrecededByNestedTypesCondition) {
           messages.push({
             code: 'EXPORTS_TYPES_SHOULD_BE_FIRST',
             args: {},

--- a/packages/publint/tests/fixtures/types-exports-versioned.js
+++ b/packages/publint/tests/fixtures/types-exports-versioned.js
@@ -1,0 +1,26 @@
+export default {
+  'package.json': JSON.stringify({
+    name: 'publint-types-exports-versioned',
+    version: '0.0.1',
+    private: true,
+    type: 'commonjs',
+    types: './main.d.ts',
+    exports: {
+      '.': {
+        'types@>=5.2': './ts5.2/main.d.ts',
+        blah: './main.js',
+        'types@>=4.6': './ts4.6/main.d.ts',
+        types: './main.d.ts',
+        default: './main.js',
+      },
+    },
+  }),
+  'ts5.2': {
+    'main.d.ts': '',
+  },
+  'ts4.6': {
+    'main.d.ts': '',
+  },
+  'main.d.ts': '',
+  'main.js': '',
+}

--- a/packages/publint/tests/fixtures/types-exports-versioned.js
+++ b/packages/publint/tests/fixtures/types-exports-versioned.js
@@ -8,7 +8,6 @@ export default {
     exports: {
       '.': {
         'types@>=5.2': './ts5.2/main.d.ts',
-        blah: './main.js',
         'types@>=4.6': './ts4.6/main.d.ts',
         types: './main.d.ts',
         default: './main.js',

--- a/packages/publint/tests/playground.test.js
+++ b/packages/publint/tests/playground.test.js
@@ -144,6 +144,8 @@ testFixture('types-exports-resolution-dual-explicit', [
   'EXPORT_TYPES_INVALID_FORMAT',
 ])
 
+testFixture('types-exports-versioned', [])
+
 testFixture('types-versions', [])
 
 testFixture('umd', ['FILE_INVALID_FORMAT', 'FILE_INVALID_FORMAT'])


### PR DESCRIPTION
Allows for versioned `types` conditions to precede the default `types` condition in exports

Closes https://github.com/publint/publint/issues/137