### PR TITLE
Rename EXPORT_TYPES_INVALID_FORMAT to EXPORTS_TYPES_INVALID_FORMAT

### DIFF
--- a/.changeset/four-pears-push.md
+++ b/.changeset/four-pears-push.md
@@ -1,5 +1,5 @@
 ---
-"publint": patch
+'publint': patch
 ---
 
 Rename `EXPORT_TYPES_INVALID_FORMAT` message to `EXPORTS_TYPES_INVALID_FORMAT`

--- a/.changeset/four-pears-push.md
+++ b/.changeset/four-pears-push.md
@@ -1,0 +1,5 @@
+---
+"publint": patch
+---
+
+Rename `EXPORT_TYPES_INVALID_FORMAT` message to `EXPORTS_TYPES_INVALID_FORMAT`

--- a/packages/publint/src/index.d.ts
+++ b/packages/publint/src/index.d.ts
@@ -80,9 +80,8 @@ export type Message =
         expectExtension?: string
       }
     >
-  // TODO: rename EXPORT to EXPORTS (i messed up)
   | BaseMessage<
-      'EXPORT_TYPES_INVALID_FORMAT',
+      'EXPORTS_TYPES_INVALID_FORMAT',
       {
         condition: string
         actualFormat: string

--- a/packages/publint/src/node/message.js
+++ b/packages/publint/src/node/message.js
@@ -130,7 +130,7 @@ export function formatMessage(m, pkg, opts = {}) {
         return `${c.bold(fp(m.path))} types is not exported. Consider adding ${c.bold(fp(m.path) + '.types')}: "${c.bold(typesFilePath)}" to be compatible with TypeScript's ${c.bold('"moduleResolution": "bundler"')} compiler option.`
       }
     }
-    case 'EXPORT_TYPES_INVALID_FORMAT': {
+    case 'EXPORTS_TYPES_INVALID_FORMAT': {
       // convert ['exports', 'types'] -> ['exports', '<condition>', 'types']
       // convert ['exports', 'types', 'node'] -> ['exports', 'types', 'node', '<condition>']
       const expectPath = m.path.slice()

--- a/packages/publint/src/shared/core.js
+++ b/packages/publint/src/shared/core.js
@@ -1003,7 +1003,7 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
 
               if (dtsActualFormat !== dtsExpectFormat) {
                 messages.push({
-                  code: 'EXPORT_TYPES_INVALID_FORMAT',
+                  code: 'EXPORTS_TYPES_INVALID_FORMAT',
                   args: {
                     condition: format,
                     actualFormat: dtsActualFormat,

--- a/packages/publint/tests/playground.test.js
+++ b/packages/publint/tests/playground.test.js
@@ -132,7 +132,7 @@ testFixture('types-exports-resolution', [])
 testFixture('types-exports-resolution-cjs', [])
 
 testFixture('types-exports-resolution-cjs-explicit', [
-  'EXPORT_TYPES_INVALID_FORMAT',
+  'EXPORTS_TYPES_INVALID_FORMAT',
 ])
 
 testFixture('types-exports-resolution-dual', [
@@ -141,7 +141,7 @@ testFixture('types-exports-resolution-dual', [
 ])
 
 testFixture('types-exports-resolution-dual-explicit', [
-  'EXPORT_TYPES_INVALID_FORMAT',
+  'EXPORTS_TYPES_INVALID_FORMAT',
 ])
 
 testFixture('types-versions', [])

--- a/site/src/app/utils/message.js
+++ b/site/src/app/utils/message.js
@@ -110,7 +110,7 @@ function messageToString(m, pkg) {
         return `The types is not exported. Consider adding ${bold(fp(m.path) + '.types')}: "${bold(typesFilePath)}" to be compatible with TypeScript's ${bold('"moduleResolution": "bundler"')} compiler option.`
       }
     }
-    case 'EXPORT_TYPES_INVALID_FORMAT': {
+    case 'EXPORTS_TYPES_INVALID_FORMAT': {
       // convert ['exports', 'types'] -> ['exports', '<condition>', 'types']
       // convert ['exports', 'types', 'node'] -> ['exports', 'types', 'node', '<condition>']
       const expectPath = m.path.slice()

--- a/site/src/pages/rules.md
+++ b/site/src/pages/rules.md
@@ -91,6 +91,10 @@ This message may also provide helpful hints depending on the types format, which
 
 ## `EXPORT_TYPES_INVALID_FORMAT`
 
+Renamed to [EXPORTS_TYPES_INVALID_FORMAT](#exports_types_invalid_format).
+
+## `EXPORTS_TYPES_INVALID_FORMAT`
+
 Since TypeScript 5.0, it has emphasized that type files (`*.d.ts`) are also affected by its ESM and CJS context, and both contexts affect how the exported types is interpreted. This means that you can't share a single type file for both ESM and CJS exports of your library. You need to have two type files (albeit largely similar contents) when dual-publishing your library.
 
 When specifying the `"types"` conditions in the `"exports"` field, the types format is determined via its extension or its closest `package.json` `"type"` value, similar to the rule in [`IMPLICIT_INDEX_JS_INVALID_FORMAT`](#implicit_index_js_invalid_format). In short:


### PR DESCRIPTION
Resolving this TODO about renaming the rule. Since this is a breaking change let me know how you'd like to proceed.