### PR TITLE
Add `esbuild` and `sharp` to pnpm.onlyBuiltDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "overrides": {
       "prettier": "$prettier",
       "unconfig": "npm:@bluwy/unconfig@^0.6.1"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "sharp"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
       "unconfig": "npm:@bluwy/unconfig@^0.6.1"
     },
     "onlyBuiltDependencies": [
+      "esbuild",
       "sharp"
     ]
   }


### PR DESCRIPTION
pnpm 10 no longer executes scripts by default and needs to be specified manually.