### PR TITLE
Add support for checking files in bin field

### DIFF
--- a/.changeset/clean-wolves-clean.md
+++ b/.changeset/clean-wolves-clean.md
@@ -1,0 +1,5 @@
+---
+'publint': patch
+---
+
+Check the `"bin"` field if the referenced file exists, has the correct JS format, and can be executed

--- a/packages/publint/src/index.d.ts
+++ b/packages/publint/src/index.d.ts
@@ -120,6 +120,7 @@ export type Message =
       }
     >
   | BaseMessage<'LOCAL_DEPENDENCY'>
+  | BaseMessage<'BIN_FILE_MISSING_NODE_SHEBANG'>
 
 export interface PackFile {
   name: string

--- a/packages/publint/src/index.d.ts
+++ b/packages/publint/src/index.d.ts
@@ -120,7 +120,7 @@ export type Message =
       }
     >
   | BaseMessage<'LOCAL_DEPENDENCY'>
-  | BaseMessage<'BIN_FILE_MISSING_NODE_SHEBANG'>
+  | BaseMessage<'BIN_FILE_NOT_EXECUTABLE'>
 
 export interface PackFile {
   name: string

--- a/packages/publint/src/node/message.js
+++ b/packages/publint/src/node/message.js
@@ -204,6 +204,9 @@ export function formatMessage(m, pkg, opts = {}) {
     case 'LOCAL_DEPENDENCY':
       // prettier-ignore
       return `The "${c.bold(m.path[m.path.length - 1])}" dependency references "${c.bold(pv(m.path))}" that will likely not work when installed by end-users.`
+    case 'BIN_FILE_MISSING_NODE_SHEBANG':
+      // prettier-ignore
+      return `${c.bold(pv(m.path))} does not start with ${c.bold('#!/usr/bin/env node')}.`
     default:
       return
   }

--- a/packages/publint/src/node/message.js
+++ b/packages/publint/src/node/message.js
@@ -206,7 +206,7 @@ export function formatMessage(m, pkg, opts = {}) {
       return `The "${c.bold(m.path[m.path.length - 1])}" dependency references "${c.bold(pv(m.path))}" that will likely not work when installed by end-users.`
     case 'BIN_FILE_NOT_EXECUTABLE':
       // prettier-ignore
-      return `${c.bold(pv(m.path))} does not start with ${c.bold('#!/usr/bin/env')}.`
+      return `${c.bold(fp(m.path))} is ${c.bold(pv(m.path))} but the file is not executable. It should start with shebang, e.g. ${c.bold('#!/usr/bin/env node')}.`
     default:
       return
   }

--- a/packages/publint/src/node/message.js
+++ b/packages/publint/src/node/message.js
@@ -204,9 +204,9 @@ export function formatMessage(m, pkg, opts = {}) {
     case 'LOCAL_DEPENDENCY':
       // prettier-ignore
       return `The "${c.bold(m.path[m.path.length - 1])}" dependency references "${c.bold(pv(m.path))}" that will likely not work when installed by end-users.`
-    case 'BIN_FILE_MISSING_NODE_SHEBANG':
+    case 'BIN_FILE_NOT_EXECUTABLE':
       // prettier-ignore
-      return `${c.bold(pv(m.path))} does not start with ${c.bold('#!/usr/bin/env node')}.`
+      return `${c.bold(pv(m.path))} does not start with ${c.bold('#!/usr/bin/env')}.`
     default:
       return
   }

--- a/packages/publint/src/shared/core.js
+++ b/packages/publint/src/shared/core.js
@@ -28,7 +28,7 @@ import {
   isShorthandRepositoryUrl,
   isShorthandGitHubOrGitLabUrl,
   isDeprecatedGitHubGitUrl,
-  startsWithNodeShebang,
+  startsWithShebang,
 } from './utils.js'
 
 /**
@@ -1116,10 +1116,10 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
         const binPath = vfs.pathJoin(pkgDir, binValue)
         const binContent = await readFile(binPath, currentPath)
         if (binContent === false) return
-        // Check that file has node shebang
-        if (!startsWithNodeShebang(binContent)) {
+        // Check that file has shebang
+        if (!startsWithShebang(binContent)) {
           messages.push({
-            code: 'BIN_FILE_MISSING_NODE_SHEBANG',
+            code: 'BIN_FILE_NOT_EXECUTABLE',
             args: {},
             path: currentPath,
             type: 'error',

--- a/packages/publint/src/shared/core.js
+++ b/packages/publint/src/shared/core.js
@@ -28,6 +28,7 @@ import {
   isShorthandRepositoryUrl,
   isShorthandGitHubOrGitLabUrl,
   isDeprecatedGitHubGitUrl,
+  startsWithNodeShebang,
 } from './utils.js'
 
 /**
@@ -444,6 +445,12 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
     })
   }
 
+  // check file existence for bin field
+  const [bin, binPkgPath] = getPublishedField(rootPkg, 'bin')
+  if (bin) {
+    crawlBin(bin, binPkgPath)
+  }
+
   await promiseQueue.wait()
 
   if (strict) {
@@ -763,7 +770,7 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
               return
             }
             // file format checks isn't required for `browser` condition or exports
-            // after the node condtion, as nodejs doesn't use it, only bundlers do,
+            // after the node condition, as nodejs doesn't use it, only bundlers do,
             // which doesn't care of the format
             if (isAfterNodeCondition || currentPath.includes('browser')) return
             const actualFormat = getCodeFormat(fileContent)
@@ -1097,5 +1104,58 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
       // TODO: handle nested exports key
     }
     return typesFilePath
+  }
+
+  /**
+   * @param {any} binValue
+   * @param {string[]} currentPath
+   */
+  function crawlBin(binValue, currentPath) {
+    if (typeof binValue === 'string') {
+      promiseQueue.push(async () => {
+        const binPath = vfs.pathJoin(pkgDir, binValue)
+        const binContent = await readFile(binPath, currentPath)
+        if (binContent === false) return
+        // Check that file has node shebang
+        if (!startsWithNodeShebang(binContent)) {
+          messages.push({
+            code: 'BIN_FILE_MISSING_NODE_SHEBANG',
+            args: {},
+            path: currentPath,
+            type: 'error',
+          })
+        }
+        // Check format of file
+        const actualFormat = getCodeFormat(binContent)
+        const expectFormat = await getFilePathFormat(binPath, vfs)
+        if (
+          actualFormat !== expectFormat &&
+          actualFormat !== 'unknown' &&
+          actualFormat !== 'mixed'
+        ) {
+          const actualExtension = vfs.getExtName(binPath)
+          messages.push({
+            code: isExplicitExtension(actualExtension)
+              ? 'FILE_INVALID_EXPLICIT_FORMAT'
+              : 'FILE_INVALID_FORMAT',
+            args: {
+              actualFormat,
+              expectFormat,
+              actualExtension,
+              expectExtension: getCodeFormatExtension(actualFormat),
+            },
+            path: currentPath,
+            type: 'warning',
+          })
+        }
+      })
+    } else if (typeof binValue === 'object') {
+      for (const key in binValue) {
+        const binPath = currentPath.concat(key)
+        // Nested commands are not allowed
+        if (!ensureTypeOfField(binValue[key], ['string'], binPath)) continue
+        crawlBin(binValue[key], binPath)
+      }
+    }
   }
 }

--- a/packages/publint/src/shared/core.js
+++ b/packages/publint/src/shared/core.js
@@ -1116,6 +1116,9 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
         const binPath = vfs.pathJoin(pkgDir, binValue)
         const binContent = await readFile(binPath, currentPath)
         if (binContent === false) return
+        // Skip checks if file is not lintable
+        if (!isFilePathLintable(binValue)) return
+
         // Check that file has shebang
         if (!startsWithShebang(binContent)) {
           messages.push({
@@ -1125,6 +1128,7 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
             type: 'error',
           })
         }
+
         // Check format of file
         const actualFormat = getCodeFormat(binContent)
         const expectFormat = await getFilePathFormat(binPath, vfs)

--- a/packages/publint/src/shared/utils.js
+++ b/packages/publint/src/shared/utils.js
@@ -496,3 +496,10 @@ export function replaceLast(str, search, replace) {
   if (index === -1) return str
   return str.slice(0, index) + replace + str.slice(index + search.length)
 }
+
+/**
+ * @param {string} code
+ */
+export function startsWithNodeShebang(code) {
+  return code.startsWith('#!/usr/bin/env node')
+}

--- a/packages/publint/src/shared/utils.js
+++ b/packages/publint/src/shared/utils.js
@@ -500,6 +500,6 @@ export function replaceLast(str, search, replace) {
 /**
  * @param {string} code
  */
-export function startsWithNodeShebang(code) {
-  return code.startsWith('#!/usr/bin/env node')
+export function startsWithShebang(code) {
+  return code.startsWith('#!/usr/bin/env')
 }

--- a/packages/publint/tests/fixtures/bin-file-missing-node-shebang.js
+++ b/packages/publint/tests/fixtures/bin-file-missing-node-shebang.js
@@ -1,0 +1,10 @@
+export default {
+  'package.json': JSON.stringify({
+    name: 'publint-bin-file-missing-node-shebang',
+    version: '0.0.1',
+    private: true,
+    type: 'commonjs',
+    bin: 'cli.js',
+  }),
+  'cli.js': '',
+}

--- a/packages/publint/tests/fixtures/bin-file-missing-shebang.js
+++ b/packages/publint/tests/fixtures/bin-file-missing-shebang.js
@@ -1,6 +1,6 @@
 export default {
   'package.json': JSON.stringify({
-    name: 'publint-bin-file-missing-node-shebang',
+    name: 'publint-bin-file-missing-shebang',
     version: '0.0.1',
     private: true,
     type: 'commonjs',

--- a/packages/publint/tests/fixtures/bin-file-not-lintable.js
+++ b/packages/publint/tests/fixtures/bin-file-not-lintable.js
@@ -4,7 +4,7 @@ export default {
     version: '0.0.1',
     private: true,
     type: 'commonjs',
-    bin: 'cli.js',
+    bin: 'cli',
   }),
-  'cli.js': "console.log('foo')",
+  cli: '',
 }

--- a/packages/publint/tests/fixtures/bin-file-not-lintable.js
+++ b/packages/publint/tests/fixtures/bin-file-not-lintable.js
@@ -1,6 +1,6 @@
 export default {
   'package.json': JSON.stringify({
-    name: 'publint-bin-file-missing-shebang',
+    name: 'publint-bin-not-lintable',
     version: '0.0.1',
     private: true,
     type: 'commonjs',

--- a/packages/publint/tests/fixtures/missing-files.js
+++ b/packages/publint/tests/fixtures/missing-files.js
@@ -21,6 +21,7 @@ export default {
       './not-published': './not-published.js',
     },
     files: ['package.json'],
+    bin: 'missing.js',
   }),
   'not-published.js': '',
 }

--- a/packages/publint/tests/playground.test.js
+++ b/packages/publint/tests/playground.test.js
@@ -193,7 +193,7 @@ testFixture('invalid-repository-value-object-deprecated', [
   },
 ])
 
-testFixture('bin-file-missing-node-shebang', ['BIN_FILE_NOT_EXECUTABLE'])
+testFixture('bin-file-missing-shebang', ['BIN_FILE_NOT_EXECUTABLE'])
 
 /**
  * @typedef {{

--- a/packages/publint/tests/playground.test.js
+++ b/packages/publint/tests/playground.test.js
@@ -195,6 +195,8 @@ testFixture('invalid-repository-value-object-deprecated', [
 
 testFixture('bin-file-missing-shebang', ['BIN_FILE_NOT_EXECUTABLE'])
 
+testFixture('bin-file-not-lintable', [])
+
 /**
  * @typedef {{
  *  level?: import('../src/index.d.ts').Options['level']

--- a/packages/publint/tests/playground.test.js
+++ b/packages/publint/tests/playground.test.js
@@ -38,7 +38,7 @@ testFixture('invalid-jsx-extensions', [
 ])
 
 testFixture('missing-files', [
-  ...Array(8).fill('FILE_DOES_NOT_EXIST'),
+  ...Array(9).fill('FILE_DOES_NOT_EXIST'),
   'FILE_NOT_PUBLISHED',
   'USE_EXPORTS_OR_IMPORTS_BROWSER',
 ])
@@ -192,6 +192,8 @@ testFixture('invalid-repository-value-object-deprecated', [
     type: 'suggestion',
   },
 ])
+
+testFixture('bin-file-missing-node-shebang', ['BIN_FILE_MISSING_NODE_SHEBANG'])
 
 /**
  * @typedef {{

--- a/packages/publint/tests/playground.test.js
+++ b/packages/publint/tests/playground.test.js
@@ -193,7 +193,7 @@ testFixture('invalid-repository-value-object-deprecated', [
   },
 ])
 
-testFixture('bin-file-missing-node-shebang', ['BIN_FILE_MISSING_NODE_SHEBANG'])
+testFixture('bin-file-missing-node-shebang', ['BIN_FILE_NOT_EXECUTABLE'])
 
 /**
  * @typedef {{

--- a/site/src/app/utils/message.js
+++ b/site/src/app/utils/message.js
@@ -184,6 +184,9 @@ function messageToString(m, pkg) {
     case 'LOCAL_DEPENDENCY':
       // prettier-ignore
       return `This dependency references a local package that will likely not work when installed by end-users.`
+    case 'BIN_FILE_MISSING_NODE_SHEBANG':
+      // prettier-ignore
+      return `${bold(pv(m.path))} does not start with ${bold('#!/usr/bin/env node')}.`
     default:
       return
   }

--- a/site/src/app/utils/message.js
+++ b/site/src/app/utils/message.js
@@ -184,9 +184,9 @@ function messageToString(m, pkg) {
     case 'LOCAL_DEPENDENCY':
       // prettier-ignore
       return `This dependency references a local package that will likely not work when installed by end-users.`
-    case 'BIN_FILE_MISSING_NODE_SHEBANG':
+    case 'BIN_FILE_NOT_EXECUTABLE':
       // prettier-ignore
-      return `${bold(pv(m.path))} does not start with ${bold('#!/usr/bin/env node')}.`
+      return `${bold(pv(m.path))} does not start with ${bold('#!/usr/bin/env')}.`
     default:
       return
   }

--- a/site/src/app/utils/message.js
+++ b/site/src/app/utils/message.js
@@ -186,7 +186,7 @@ function messageToString(m, pkg) {
       return `This dependency references a local package that will likely not work when installed by end-users.`
     case 'BIN_FILE_NOT_EXECUTABLE':
       // prettier-ignore
-      return `${bold(pv(m.path))} does not start with ${bold('#!/usr/bin/env')}.`
+      return `This bin file is not executable. It should start with a shebang, e.g. ${bold('#!/usr/bin/env node')}.`
     default:
       return
   }

--- a/site/src/pages/rules.md
+++ b/site/src/pages/rules.md
@@ -277,4 +277,12 @@ When a dependency with the `file:` or `link:` protocol is used, e.g. `file:../pa
 
 ## `BIN_FILE_NOT_EXECUTABLE`
 
-Ensure the file referenced in `bin` starts with `#!/usr/bin/env` so that the script is executable. See [package.json#bin](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#bin).
+Ensure the file referenced in the `"bin"` field starts with a shebang, e.g. `#!/usr/bin/env node`, so that the script is executable. See [package.json#bin](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#bin) for more information.
+
+For example, the bin file should look like this:
+
+```js
+#!/usr/bin/env node
+
+console.log('CLI is running')
+```

--- a/site/src/pages/rules.md
+++ b/site/src/pages/rules.md
@@ -275,6 +275,6 @@ An example config that meets these criteria may look like this:
 
 When a dependency with the `file:` or `link:` protocol is used, e.g. `file:../path/to/local/package`, this error is shown as it's likely to not work when installed by end-users. This helps prevent accidentally publishing a package that references local dependencies that were used for testing or debugging.
 
-## `BIN_FILE_MISSING_NODE_SHEBANG`
+## `BIN_FILE_NOT_EXECUTABLE`
 
-Ensure the file referenced in `bin` starts with `#!/usr/bin/env node` so that the script is run using Node.js. See [package.json#bin](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#bin).
+Ensure the file referenced in `bin` starts with `#!/usr/bin/env` so that the script is executable. See [package.json#bin](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#bin).

--- a/site/src/pages/rules.md
+++ b/site/src/pages/rules.md
@@ -274,3 +274,7 @@ An example config that meets these criteria may look like this:
 ## `LOCAL_DEPENDENCY`
 
 When a dependency with the `file:` or `link:` protocol is used, e.g. `file:../path/to/local/package`, this error is shown as it's likely to not work when installed by end-users. This helps prevent accidentally publishing a package that references local dependencies that were used for testing or debugging.
+
+## `BIN_FILE_MISSING_NODE_SHEBANG`
+
+Ensure the file referenced in `bin` starts with `#!/usr/bin/env node` so that the script is run using Node.js. See [package.json#bin](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#bin).


### PR DESCRIPTION
Adds support for checking files in the bin field.  This PR the following checks
* checks the files exist
* checks the files are the correct format
* checks the files start with a node shebang as mentioned in the [package.json#bin](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#bin)

Closes https://github.com/publint/publint/issues/145