### PR TITLE
Change NodeJS to Node.js in messages

### DIFF
--- a/packages/publint/src/node/message.js
+++ b/packages/publint/src/node/message.js
@@ -68,10 +68,10 @@ export function formatMessage(m, pkg, opts = {}) {
       return `${c.bold(fp(m.path))} is ${c.bold(pv(m.path))} but the file is not published. Is it specified in ${c.bold('pkg.files')}?`
     case 'HAS_ESM_MAIN_BUT_NO_EXPORTS':
       // prettier-ignore
-      return `${c.bold('pkg.main')} is an ESM file, but it is usually better to use ${c.bold('pkg.exports')} instead. If you don't support NodeJS 12.6 and below, you can also remove ${c.bold('pkg.main')}. (This will be a breaking change)`
+      return `${c.bold('pkg.main')} is an ESM file, but it is usually better to use ${c.bold('pkg.exports')} instead. If you don't support Node.js 12.6 and below, you can also remove ${c.bold('pkg.main')}. (This will be a breaking change)`
     case 'HAS_MODULE_BUT_NO_EXPORTS':
       // prettier-ignore
-      return `${c.bold('pkg.module')} is used to output ESM, but ${c.bold('pkg.exports')} is not defined. As NodeJS doesn't read ${c.bold('pkg.module')}, the ESM output may be skipped. Consider adding ${c.bold('pkg.exports')} to export the ESM output. ${c.bold('pkg.module')} can usually be removed alongside too. (This will be a breaking change)`
+      return `${c.bold('pkg.module')} is used to output ESM, but ${c.bold('pkg.exports')} is not defined. As Node.js doesn't read ${c.bold('pkg.module')}, the ESM output may be skipped. Consider adding ${c.bold('pkg.exports')} to export the ESM output. ${c.bold('pkg.module')} can usually be removed alongside too. (This will be a breaking change)`
     case 'MODULE_SHOULD_BE_ESM':
       // prettier-ignore
       return `${c.bold('pkg.module')} should be ESM, but the code is written in CJS.`
@@ -114,7 +114,7 @@ export function formatMessage(m, pkg, opts = {}) {
       return `The package ${c.bold('publishes internal tests or config files')}. You can use ${c.bold('pkg.files')} to only publish certain files and save user bandwidth.`
     case 'USE_TYPE':
       // prettier-ignore
-      return `The package does not specify the ${c.bold('"type"')} field. NodeJS may attempt to detect the package type causing a small performance hit. Consider adding ${c.bold('"type"')}: "${c.bold('commonjs')}".`
+      return `The package does not specify the ${c.bold('"type"')} field. Node.js may attempt to detect the package type causing a small performance hit. Consider adding ${c.bold('"type"')}: "${c.bold('commonjs')}".`
     case 'USE_LICENSE':
       // prettier-ignore
       return `The package does not specify the ${c.bold('"license"')} field but a license file was detected at ${c.bold(m.args.licenseFilePath)}. Consider adding a ${c.bold('"license"')} field so it's displayed on npm.`

--- a/site/src/app/utils/message.js
+++ b/site/src/app/utils/message.js
@@ -50,10 +50,10 @@ function messageToString(m, pkg) {
       return `${bold(fp(m.path))} is ${bold(pv(m.path))} but the file is not published. Is it specified in ${bold('pkg.files')}?`
     case 'HAS_ESM_MAIN_BUT_NO_EXPORTS':
       // prettier-ignore
-      return `${bold('pkg.main')} is an ESM file, but it is usually better to use ${bold('pkg.exports')} instead. If you don't support NodeJS 12.6 and below, you can also remove ${bold('pkg.main')}. (This will be a breaking change)`
+      return `${bold('pkg.main')} is an ESM file, but it is usually better to use ${bold('pkg.exports')} instead. If you don't support Node.js 12.6 and below, you can also remove ${bold('pkg.main')}. (This will be a breaking change)`
     case 'HAS_MODULE_BUT_NO_EXPORTS':
       // prettier-ignore
-      return `${bold('pkg.module')} is used to output ESM, but ${bold('pkg.exports')} is not defined. As NodeJS doesn't read ${bold('pkg.module')}, the ESM output may be skipped. Consider adding ${bold('pkg.exports')} to export the ESM output. ${bold('pkg.module')} can usually be removed alongside too. (This will be a breaking change)`
+      return `${bold('pkg.module')} is used to output ESM, but ${bold('pkg.exports')} is not defined. As Node.js doesn't read ${bold('pkg.module')}, the ESM output may be skipped. Consider adding ${bold('pkg.exports')} to export the ESM output. ${bold('pkg.module')} can usually be removed alongside too. (This will be a breaking change)`
     case 'MODULE_SHOULD_BE_ESM':
     case 'EXPORTS_MODULE_SHOULD_BE_ESM':
       // prettier-ignore
@@ -94,7 +94,7 @@ function messageToString(m, pkg) {
       return `The package ${bold('publishes internal tests or config files')}. You can use ${bold('pkg.files')} to only publish certain files and save user bandwidth.`
     case 'USE_TYPE':
       // prettier-ignore
-      return `The package does not specify the ${bold('"type"')} field. NodeJS may attempt to detect the package type causing a small performance hit. Consider adding ${bold('"type"')}: "${bold('commonjs')}".`
+      return `The package does not specify the ${bold('"type"')} field. Node.js may attempt to detect the package type causing a small performance hit. Consider adding ${bold('"type"')}: "${bold('commonjs')}".`
     case 'USE_LICENSE':
       // prettier-ignore
       return `The package does not specify the ${bold('"license"')} field but a license file was detected at ${bold(m.args.licenseFilePath)}. Consider adding a ${bold('"license"')} field so it's displayed on npm.`


### PR DESCRIPTION
Updates some of the messages to change "NodeJS" to the official name "Node.js"