### PR TITLE
Support additional rules for imports field

### DIFF
--- a/.changeset/brown-paths-enjoy.md
+++ b/.changeset/brown-paths-enjoy.md
@@ -8,3 +8,5 @@ The `"imports"` field is now linted with the following rules:
 - `IMPORTS_VALUE_INVALID`: Ensure the imports value is a valid path that starts with a `./`
 - `IMPORTS_GLOB_NO_MATCHED_FILES`: Ensure the imports glob matches at least one file
 - `IMPORTS_DEFAULT_SHOULD_BE_LAST`: Ensure the `"default"` condition is last in an entrypoint's object
+- `IMPORTS_MODULE_SHOULD_BE_ESM`: Ensure the `"module"` condition file is ESM
+- `IMPORTS_MODULE_SHOULD_PRECEDE_REQUIRE`: Ensure the `"module"` condition precedes the `"require"` condition in an entrypoint's object

--- a/packages/publint/src/index.d.ts
+++ b/packages/publint/src/index.d.ts
@@ -135,8 +135,8 @@ export type Message =
   | BaseMessage<'IMPORTS_KEY_INVALID', { suggestKey: string }>
   | BaseMessage<'IMPORTS_VALUE_INVALID', { suggestValue: string }>
   | BaseMessage<'IMPORTS_GLOB_NO_MATCHED_FILES'>
-  | BaseMessage<'IMPORTS_MODULE_SHOULD_PRECEDE_REQUIRE'>
   | BaseMessage<'IMPORTS_DEFAULT_SHOULD_BE_LAST'>
+  | BaseMessage<'IMPORTS_MODULE_SHOULD_PRECEDE_REQUIRE'>
   | BaseMessage<'IMPORTS_MODULE_SHOULD_BE_ESM'>
 
 export interface PackFile {

--- a/packages/publint/src/index.d.ts
+++ b/packages/publint/src/index.d.ts
@@ -135,7 +135,9 @@ export type Message =
   | BaseMessage<'IMPORTS_KEY_INVALID', { suggestKey: string }>
   | BaseMessage<'IMPORTS_VALUE_INVALID', { suggestValue: string }>
   | BaseMessage<'IMPORTS_GLOB_NO_MATCHED_FILES'>
+  | BaseMessage<'IMPORTS_MODULE_SHOULD_PRECEDE_REQUIRE'>
   | BaseMessage<'IMPORTS_DEFAULT_SHOULD_BE_LAST'>
+  | BaseMessage<'IMPORTS_MODULE_SHOULD_BE_ESM'>
 
 export interface PackFile {
   name: string

--- a/packages/publint/src/node/message.js
+++ b/packages/publint/src/node/message.js
@@ -86,7 +86,8 @@ export function formatMessage(m, pkg, opts = {}) {
     case 'EXPORTS_TYPES_SHOULD_BE_FIRST':
       // prettier-ignore
       return `${c.bold(fp(m.path))} should be the first in the object as conditions are order-sensitive so it can be resolved by TypeScript.`
-    case 'EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE': {
+    case 'EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE':
+    case 'IMPORTS_MODULE_SHOULD_PRECEDE_REQUIRE': {
       // prettier-ignore
       return `${c.bold(fp(m.path))} should come before the "require" condition so it can take precedence when used by a bundler.`
     }
@@ -95,6 +96,7 @@ export function formatMessage(m, pkg, opts = {}) {
       // prettier-ignore
       return `${c.bold(fp(m.path))} should be the last in the object so it doesn't take precedence over the keys following it.`
     case 'EXPORTS_MODULE_SHOULD_BE_ESM':
+    case 'IMPORTS_MODULE_SHOULD_BE_ESM':
       // prettier-ignore
       return `${c.bold(fp(m.path))} should be ESM, but the code is written in CJS.`
     case 'EXPORTS_VALUE_INVALID':

--- a/packages/publint/src/shared/core.js
+++ b/packages/publint/src/shared/core.js
@@ -793,11 +793,13 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
             if (fileContent === false) return
             if (!isFileContentLintable(fileContent)) return
             // the `module` condition is only used by bundlers and must be ESM
-            if (!isImports && currentPath.includes('module')) {
+            if (currentPath.includes('module')) {
               const actualFormat = getCodeFormat(fileContent)
               if (actualFormat === 'CJS') {
                 messages.push({
-                  code: 'EXPORTS_MODULE_SHOULD_BE_ESM',
+                  code: isImports
+                    ? 'IMPORTS_MODULE_SHOULD_BE_ESM'
+                    : 'EXPORTS_MODULE_SHOULD_BE_ESM',
                   args: {},
                   path: currentPath,
                   type: 'error',
@@ -907,13 +909,14 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
       // if there is a 'require' and a 'module' condition at the same level,
       // then 'module' should always precede 'require'
       if (
-        !isImports &&
         'module' in exportsValue &&
         'require' in exportsValue &&
         exportsKeys.indexOf('module') > exportsKeys.indexOf('require')
       ) {
         messages.push({
-          code: 'EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE',
+          code: isImports
+            ? 'IMPORTS_MODULE_SHOULD_PRECEDE_REQUIRE'
+            : 'EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE',
           args: {},
           path: currentPath.concat('module'),
           type: 'error',

--- a/site/src/app/utils/message.js
+++ b/site/src/app/utils/message.js
@@ -56,6 +56,7 @@ function messageToString(m, pkg) {
       return `${bold('pkg.module')} is used to output ESM, but ${bold('pkg.exports')} is not defined. As Node.js doesn't read ${bold('pkg.module')}, the ESM output may be skipped. Consider adding ${bold('pkg.exports')} to export the ESM output. ${bold('pkg.module')} can usually be removed alongside too. (This will be a breaking change)`
     case 'MODULE_SHOULD_BE_ESM':
     case 'EXPORTS_MODULE_SHOULD_BE_ESM':
+    case 'IMPORTS_MODULE_SHOULD_BE_ESM':
       // prettier-ignore
       return `Should be ESM, but the code is written in CJS.`
     case 'EXPORTS_GLOB_NO_MATCHED_FILES':
@@ -69,7 +70,8 @@ function messageToString(m, pkg) {
     case 'EXPORTS_TYPES_SHOULD_BE_FIRST':
       // prettier-ignore
       return `Should be the first in the object as conditions are order-sensitive so it can be resolved by TypeScript.`
-    case 'EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE': {
+    case 'EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE':
+    case 'IMPORTS_MODULE_SHOULD_PRECEDE_REQUIRE': {
       // prettier-ignore
       return `Should come before the "require" condition so it can take precedence when used by a bundler.`
     }

--- a/site/src/pages/rules.md
+++ b/site/src/pages/rules.md
@@ -111,6 +111,8 @@ The `"exports"` field should not have globs defined with trailing slashes. It is
 
 Ensure the `"module"` condition comes before the `"require"` condition. Due to the way conditions are matched top-to-bottom, the `"module"` condition (used in bundler contexts only) must come before a `"require"` condition, so it has the opportunity to take precedence.
 
+(Works similarly to [IMPORTS_MODULE_SHOULD_PRECEDE_REQUIRE](#imports_module_should_precede_require)).
+
 ## `EXPORTS_TYPES_SHOULD_BE_FIRST` {#exports_types_should_be_first}
 
 Ensure `"types"` condition to be the first. As `"exports"` conditions are order-sensitive, in order for TypeScript to be able to resolve the types first, the `"types"` condition should be the first condition before any other JS exports. See the [TypeScript docs](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports) for more information.
@@ -175,6 +177,8 @@ The example [above](#exports_types_should_be_first) also applies here as to why 
 ## `EXPORTS_MODULE_SHOULD_BE_ESM` {#exports_module_should_be_esm}
 
 The `"module"` condition should be ESM only. This condition is used to prevent the [dual package hazard](https://nodejs.org/api/packages.html#dual-package-hazard) in bundlers so `import` and `require` will both resolve to this condition, deduplicating the dual instances. The [esbuild docs](https://esbuild.github.io/api/#how-conditions-work) has a more in-depth explanation.
+
+(Works similarly to [IMPORTS_MODULE_SHOULD_BE_ESM](#imports_module_should_be_esm)).
 
 ## `EXPORTS_VALUE_INVALID` {#exports_value_invalid}
 
@@ -351,8 +355,20 @@ If the `"imports"` field contains glob paths, but it doesn't match any files, re
 
 (Works similarly to [EXPORTS_GLOB_NO_MATCHED_FILES](#exports_glob_no_matched_files)).
 
+## `IMPORTS_MODULE_SHOULD_PRECEDE_REQUIRE` {#imports_module_should_precede_require}
+
+Ensure the `"module"` condition comes before the `"require"` condition. Due to the way conditions are matched top-to-bottom, the `"module"` condition (used in bundler contexts only) must come before a `"require"` condition, so it has the opportunity to take precedence.
+
+(Works similarly to [EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE](#exports_module_should_precede_require)).
+
 ## `IMPORTS_DEFAULT_SHOULD_BE_LAST` {#imports_default_should_be_last}
 
 Ensure `"default"` condition to be the last according to the [Node.js docs](https://nodejs.org/api/packages.html#conditional-exports), but it's also because the `"imports"` field is order-based.
 
 (Works similarly to [EXPORTS_DEFAULT_SHOULD_BE_LAST](#exports_default_should_be_last)).
+
+## `IMPORTS_MODULE_SHOULD_BE_ESM` {#imports_module_should_be_esm}
+
+The `"module"` condition should be ESM only. This condition is used to prevent the [dual package hazard](https://nodejs.org/api/packages.html#dual-package-hazard) in bundlers so `import` and `require` will both resolve to this condition, deduplicating the dual instances. The [esbuild docs](https://esbuild.github.io/api/#how-conditions-work) has a more in-depth explanation.
+
+(Works similarly to [EXPORTS_MODULE_SHOULD_BE_ESM](#exports_module_should_be_esm)).

--- a/site/src/pages/rules.md
+++ b/site/src/pages/rules.md
@@ -355,17 +355,17 @@ If the `"imports"` field contains glob paths, but it doesn't match any files, re
 
 (Works similarly to [EXPORTS_GLOB_NO_MATCHED_FILES](#exports_glob_no_matched_files)).
 
-## `IMPORTS_MODULE_SHOULD_PRECEDE_REQUIRE` {#imports_module_should_precede_require}
-
-Ensure the `"module"` condition comes before the `"require"` condition. Due to the way conditions are matched top-to-bottom, the `"module"` condition (used in bundler contexts only) must come before a `"require"` condition, so it has the opportunity to take precedence.
-
-(Works similarly to [EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE](#exports_module_should_precede_require)).
-
 ## `IMPORTS_DEFAULT_SHOULD_BE_LAST` {#imports_default_should_be_last}
 
 Ensure `"default"` condition to be the last according to the [Node.js docs](https://nodejs.org/api/packages.html#conditional-exports), but it's also because the `"imports"` field is order-based.
 
 (Works similarly to [EXPORTS_DEFAULT_SHOULD_BE_LAST](#exports_default_should_be_last)).
+
+## `IMPORTS_MODULE_SHOULD_PRECEDE_REQUIRE` {#imports_module_should_precede_require}
+
+Ensure the `"module"` condition comes before the `"require"` condition. Due to the way conditions are matched top-to-bottom, the `"module"` condition (used in bundler contexts only) must come before a `"require"` condition, so it has the opportunity to take precedence.
+
+(Works similarly to [EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE](#exports_module_should_precede_require)).
 
 ## `IMPORTS_MODULE_SHOULD_BE_ESM` {#imports_module_should_be_esm}
 


### PR DESCRIPTION
Adds two additional rules for the `"imports"` fields:

1. `IMPORTS_MODULE_SHOULD_PRECEDE_REQUIRE` to check that the `"module"` conditions comes before the `"require"` condition.
2. `IMPORTS_MODULE_SHOULD_BE_ESM` to check that the `"module"` condition resolves to a file that is ESM.
