### PR TITLE
Update EXPORTS_GLOB_NO_DEPRECATED_SUBPATH_MAPPING message and severity

### DIFF
--- a/.changeset/eighty-bears-ask.md
+++ b/.changeset/eighty-bears-ask.md
@@ -1,0 +1,5 @@
+---
+'publint': patch
+---
+
+Update `EXPORTS_GLOB_NO_DEPRECATED_SUBPATH_MAPPING` message and severity to error

--- a/packages/publint/src/shared/core.js
+++ b/packages/publint/src/shared/core.js
@@ -699,8 +699,9 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
           return
         }
 
-        // warn deprecated subpath mapping
+        // error removed subpath mapping
         // https://nodejs.org/docs/latest-v16.x/api/packages.html#subpath-folder-mappings
+        // https://nodejs.org/docs/latest-v22.x/api/deprecations.html#dep0148-folder-mappings-in-exports-trailing-
         if (exportsValue.endsWith('/')) {
           const expectPath = currentPath.map((part) => {
             return part.endsWith('/') ? part + '*' : part
@@ -717,7 +718,7 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
             path: currentPath,
             // if a trailing glob is also specified, that means this key is for backwards compat only.
             // lower severity to suggestion instead.
-            type: expectPathAlreadyExist ? 'suggestion' : 'warning',
+            type: expectPathAlreadyExist ? 'suggestion' : 'error',
           })
           // help fix glob so we can further analyze other issues
           exportsValue += '*'

--- a/packages/publint/src/shared/message.js
+++ b/packages/publint/src/shared/message.js
@@ -84,7 +84,7 @@ export function formatMessage(m, pkg, opts = {}) {
     }
     case 'EXPORTS_GLOB_NO_DEPRECATED_SUBPATH_MAPPING':
     case 'IMPORTS_GLOB_NO_DEPRECATED_SUBPATH_MAPPING':
-      return `${h.bold(fp(m.path))} maps to a path that ends with ${h.bold('/')} which is deprecated. Use ${h.bold(fp(m.args.expectPath))}: "${h.bold(m.args.expectValue)}" instead.`
+      return `${h.bold(fp(m.path))} maps to a path that ends with ${h.bold('/')} which is a removed feature. Use ${h.bold(fp(m.args.expectPath))}: "${h.bold(m.args.expectValue)}" instead.`
     case 'EXPORTS_TYPES_SHOULD_BE_FIRST': {
       const start = opts.reference ? 'Should' : `${h.bold(fp(m.path))} should`
       return `${start} be the first in the object as conditions are order-sensitive so it can be resolved by TypeScript.`

--- a/site/src/pages/rules.md
+++ b/site/src/pages/rules.md
@@ -105,7 +105,7 @@ If the `"exports"` field contains glob paths, but it doesn't match any files, re
 
 ## `EXPORTS_GLOB_NO_DEPRECATED_SUBPATH_MAPPING` {#exports_glob_no_deprecated_subpath_mapping}
 
-The `"exports"` field should not have globs defined with trailing slashes. It is [deprecated](https://nodejs.org/docs/latest-v16.x/api/packages.html#subpath-folder-mappings) and should use [subpath patterns](https://nodejs.org/api/packages.html#subpath-patterns), e.g. a trailing `/*` instead.
+The `"exports"` field should not have globs defined with trailing slashes. It is [removed since Node 17](https://nodejs.org/docs/latest-v22.x/api/deprecations.html#dep0148-folder-mappings-in-exports-trailing-) and should use [subpath patterns](https://nodejs.org/api/packages.html#subpath-patterns), e.g. a trailing `/*` instead.
 
 ## `EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE` {#exports_module_should_precede_require}
 

--- a/site/src/pages/rules.md
+++ b/site/src/pages/rules.md
@@ -105,7 +105,7 @@ If the `"exports"` field contains glob paths, but it doesn't match any files, re
 
 ## `EXPORTS_GLOB_NO_DEPRECATED_SUBPATH_MAPPING` {#exports_glob_no_deprecated_subpath_mapping}
 
-The `"exports"` field should not have globs defined with trailing slashes. It is [removed since Node 17](https://nodejs.org/docs/latest-v22.x/api/deprecations.html#dep0148-folder-mappings-in-exports-trailing-) and should use [subpath patterns](https://nodejs.org/api/packages.html#subpath-patterns), e.g. a trailing `/*` instead.
+The `"exports"` field should not have globs defined with trailing slashes. It is [removed since Node.js 17](https://nodejs.org/docs/latest-v22.x/api/deprecations.html#dep0148-folder-mappings-in-exports-trailing-) and should use [subpath patterns](https://nodejs.org/api/packages.html#subpath-patterns), e.g. a trailing `/*` instead.
 
 ## `EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE` {#exports_module_should_precede_require}
 


### PR DESCRIPTION
Updated the message of EXPORTS_GLOB_NO_DEPRECATED_SUBPATH_MAPPING as the support for it was removed in Node 17.
Also updated the severity to error from warning as all versions supporting that feature has reached EOL.
