### PR TITLE
Fix shebang check

### DIFF
--- a/.changeset/blue-areas-obey.md
+++ b/.changeset/blue-areas-obey.md
@@ -1,0 +1,5 @@
+---
+'publint': patch
+---
+
+Fix shebang check to allow spaces after the `#!`

--- a/packages/publint/src/shared/utils.js
+++ b/packages/publint/src/shared/utils.js
@@ -520,5 +520,5 @@ export function replaceLast(str, search, replace) {
  * @param {string} code
  */
 export function startsWithShebang(code) {
-  return code.startsWith('#!/usr/bin/env')
+  return /#!\s*\/usr\/bin\/env/.test(code)
 }

--- a/packages/publint/src/shared/utils.js
+++ b/packages/publint/src/shared/utils.js
@@ -520,5 +520,5 @@ export function replaceLast(str, search, replace) {
  * @param {string} code
  */
 export function startsWithShebang(code) {
-  return /#!\s*\/usr\/bin\/env/.test(code)
+  return /^#!\s*\/usr\/bin\/env/.test(code)
 }


### PR DESCRIPTION
The shebang can contain whitespace between the `#!` and `/`, which should not cause checks to fail.