### PR TITLE
Add version number to npm url

### DIFF
--- a/site/src/app/pages/Package.svelte
+++ b/site/src/app/pages/Package.svelte
@@ -214,7 +214,7 @@
       ? extractRepoUrl(result?.pkgJson?.repository)
       : undefined,
   )
-  let npmUrl = $derived(`https://www.npmjs.com/package/${npmPkgName}`)
+  let npmUrl = $derived(`https://www.npmjs.com/package/${npmPkgName}${npmPkgVersion ? `/v/${npmPkgVersion}` : ''}`)
   let jsdelivrUrl = $derived(
     `https://www.jsdelivr.com/package/npm/${npmPkgName}`,
   )


### PR DESCRIPTION
When switching between different versions for comparison, click the npm link to view the specific code with the version number to facilitate code comparison.