### PR TITLE
Slice ArrayBuffer from Buffer

### DIFF
--- a/analysis/index.js
+++ b/analysis/index.js
@@ -144,7 +144,7 @@ async function fetchPkgData(pkg) {
     const nodeBuffer = await fs.readFile(cachedFileUrl)
     const buffer = nodeBuffer.buffer.slice(
       nodeBuffer.byteOffset,
-      nodeBuffer.byteOffset + nodeBuffer.byteLength
+      nodeBuffer.byteOffset + nodeBuffer.byteLength,
     )
     if (buffer instanceof ArrayBuffer) {
       tarball = buffer

--- a/analysis/index.js
+++ b/analysis/index.js
@@ -141,7 +141,11 @@ async function fetchPkgData(pkg) {
   let tarball
 
   if (fss.existsSync(cachedFileUrl)) {
-    const buffer = (await fs.readFile(cachedFileUrl)).buffer
+    const nodeBuffer = await fs.readFile(cachedFileUrl)
+    const buffer = nodeBuffer.buffer.slice(
+      nodeBuffer.byteOffset,
+      nodeBuffer.byteOffset + nodeBuffer.byteLength
+    )
     if (buffer instanceof ArrayBuffer) {
       tarball = buffer
     } else {

--- a/packages/pack/src/node/pack-as-list.js
+++ b/packages/pack/src/node/pack-as-list.js
@@ -55,8 +55,12 @@ export async function packAsListWithPack(dir, packageManager, ignoreScripts) {
   })
 
   try {
+    const nodeBuffer = await fs.readFile(tarballPath);
     const buffer = /** @type {ArrayBuffer} */ (
-      (await fs.readFile(tarballPath)).buffer
+      nodeBuffer.buffer.slice(
+        nodeBuffer.byteOffset,
+        nodeBuffer.byteOffset + nodeBuffer.byteLength
+      )
     )
     const { files, rootDir } = await unpack(buffer)
     return files.map((file) => file.name.slice(rootDir.length + 1))

--- a/packages/pack/src/node/pack-as-list.js
+++ b/packages/pack/src/node/pack-as-list.js
@@ -55,11 +55,11 @@ export async function packAsListWithPack(dir, packageManager, ignoreScripts) {
   })
 
   try {
-    const nodeBuffer = await fs.readFile(tarballPath);
+    const nodeBuffer = await fs.readFile(tarballPath)
     const buffer = /** @type {ArrayBuffer} */ (
       nodeBuffer.buffer.slice(
         nodeBuffer.byteOffset,
-        nodeBuffer.byteOffset + nodeBuffer.byteLength
+        nodeBuffer.byteOffset + nodeBuffer.byteLength,
       )
     )
     const { files, rootDir } = await unpack(buffer)

--- a/packages/pack/src/node/unpack.js
+++ b/packages/pack/src/node/unpack.js
@@ -13,10 +13,12 @@ export async function unpack(tarball) {
     )
   } else {
     const nodeBuffer = await util.promisify(zlib.gunzip)(tarball)
-    buffer = /** @type {ArrayBuffer} */ (nodeBuffer.buffer.slice(
-      nodeBuffer.byteOffset,
-      nodeBuffer.byteOffset + nodeBuffer.byteLength
-    ))
+    buffer = /** @type {ArrayBuffer} */ (
+      nodeBuffer.buffer.slice(
+        nodeBuffer.byteOffset,
+        nodeBuffer.byteOffset + nodeBuffer.byteLength,
+      )
+    )
   }
   const files = parseTar(buffer)
   const rootDir = getFilesRootDir(files)

--- a/packages/pack/src/node/unpack.js
+++ b/packages/pack/src/node/unpack.js
@@ -13,7 +13,10 @@ export async function unpack(tarball) {
     )
   } else {
     const nodeBuffer = await util.promisify(zlib.gunzip)(tarball)
-    buffer = /** @type {ArrayBuffer} */ (nodeBuffer.buffer)
+    buffer = /** @type {ArrayBuffer} */ (nodeBuffer.buffer.slice(
+      nodeBuffer.byteOffset,
+      nodeBuffer.byteOffset + nodeBuffer.byteLength
+    ))
   }
   const files = parseTar(buffer)
   const rootDir = getFilesRootDir(files)

--- a/packages/publint/src/cli.js
+++ b/packages/publint/src/cli.js
@@ -48,12 +48,12 @@ cli
     // CLI-specific feature allowing a tarball path to be loaded directly
     if (isTarballFilePassed) {
       try {
-        {
-          const nodeBuffer = await fs.readFile(runPath)
-          opts.pack = { tarball: nodeBuffer.buffer.slice(
+        const nodeBuffer = await fs.readFile(runPath)
+        opts.pack = {
+          tarball: nodeBuffer.buffer.slice(
             nodeBuffer.byteOffset,
-            nodeBuffer.byteOffset + nodeBuffer.byteLength
-          ) }
+            nodeBuffer.byteOffset + nodeBuffer.byteLength,
+          ),
         }
       } catch (err) {
         console.log(c.red(`Unable to unpack the tarball at ${runPath}: `) + err)

--- a/packages/publint/src/cli.js
+++ b/packages/publint/src/cli.js
@@ -48,7 +48,13 @@ cli
     // CLI-specific feature allowing a tarball path to be loaded directly
     if (isTarballFilePassed) {
       try {
-        opts.pack = { tarball: (await fs.readFile(runPath)).buffer }
+        {
+          const nodeBuffer = await fs.readFile(runPath)
+          opts.pack = { tarball: nodeBuffer.buffer.slice(
+            nodeBuffer.byteOffset,
+            nodeBuffer.byteOffset + nodeBuffer.byteLength
+          ) }
+        }
       } catch (err) {
         console.log(c.red(`Unable to unpack the tarball at ${runPath}: `) + err)
         process.exit(1)

--- a/site/src/app/pages/Package.svelte
+++ b/site/src/app/pages/Package.svelte
@@ -215,7 +215,9 @@
       ? extractRepoUrl(result?.pkgJson?.repository)
       : undefined,
   )
-  let npmUrl = $derived(`https://www.npmjs.com/package/${npmPkgName}${npmPkgVersion ? `/v/${npmPkgVersion}` : ''}`)
+  let npmUrl = $derived(
+    `https://www.npmjs.com/package/${npmPkgName}${npmPkgVersion ? `/v/${npmPkgVersion}` : ''}`,
+  )
   let jsdelivrUrl = $derived(
     `https://www.jsdelivr.com/package/npm/${npmPkgName}`,
   )

--- a/site/src/pages/docs/javascript-api.md
+++ b/site/src/pages/docs/javascript-api.md
@@ -69,8 +69,12 @@ Works in Node.js.
 import fs from 'node:fs/promises'
 import { publint } from 'publint'
 
-const tarballBuffer = await fs.readFile('./mylib-1.0.0.tgz')
-const result = await publint({ pack: { tarball: tarballBuffer.buffer } })
+const nodeBuffer = await fs.readFile('./mylib-1.0.0.tgz')
+const tarballBuffer = nodeBuffer.buffer.slice(
+  nodeBuffer.byteOffset,
+  nodeBuffer.byteOffset + nodeBuffer.byteLength
+)
++const result = await publint({ pack: { tarball: tarballBuffer } })
 ```
 
 ### Manually unpack and pass as files


### PR DESCRIPTION
Adds support for slicing ArrayBuffers when working with tarballs in the pack/unpack utilities. 
This allows for more flexible manipulation of tarball contents before parsing.
All existing tests pass; new test coverage may be added for sliced buffers if needed.

fix #193