### PR TITLE
Warn CJS with default export and `__esModule` marker using `exports.["default"]`

### DIFF
--- a/packages/publint/src/shared/utils.js
+++ b/packages/publint/src/shared/utils.js
@@ -38,7 +38,7 @@ export function isCodeCjs(code) {
 // Check for problematic __esModule + exports.default pattern (https://github.com/publint/publint/issues/187)
 const EXPORTS___ESMODULE_PATTERN_RE =
   /exports\.__esModule\s*=\s*true|Object\.defineProperty\s*\(\s*exports\s*,\s*["']__esModule["']\s*,\s*\{\s*value\s*:\s*true\s*\}/
-const EXPORTS_DEFAULT_PATTERN_RE = /exports\.default\s*=\s*([^\s]{7}.)/g
+const EXPORTS_DEFAULT_PATTERN_RE = /exports(?:\.default|\["default"\]|\['default'\])\s*=\s*([^\s]{7}.)/g
 /**
  * @param {string} code
  */

--- a/packages/publint/src/shared/utils.js
+++ b/packages/publint/src/shared/utils.js
@@ -38,7 +38,8 @@ export function isCodeCjs(code) {
 // Check for problematic __esModule + exports.default pattern (https://github.com/publint/publint/issues/187)
 const EXPORTS___ESMODULE_PATTERN_RE =
   /exports\.__esModule\s*=\s*true|Object\.defineProperty\s*\(\s*exports\s*,\s*["']__esModule["']\s*,\s*\{\s*value\s*:\s*true\s*\}/
-const EXPORTS_DEFAULT_PATTERN_RE = /exports(?:\.default|\["default"\]|\['default'\])\s*=\s*([^\s]{7}.)/g
+const EXPORTS_DEFAULT_PATTERN_RE =
+  /exports(?:\.default|\["default"\]|\['default'\])\s*=\s*([^\s]{7}.)/g
 /**
  * @param {string} code
  */

--- a/packages/publint/tests/utils.test.js
+++ b/packages/publint/tests/utils.test.js
@@ -167,6 +167,18 @@ test('hasEsModuleAndExportsDefault', () => {
   ).toEqual(true)
   expect(
     hasEsModuleAndExportsDefault(`
+    exports.__esModule=true;
+    exports["default"]=megalodon_1.default;
+  `),
+  ).toEqual(true)
+  expect(
+    hasEsModuleAndExportsDefault(`
+    exports.__esModule=true;
+    exports['default']=megalodon_1.default;
+  `),
+  ).toEqual(true)
+  expect(
+    hasEsModuleAndExportsDefault(`
     export default function foo() {}
   `),
   ).toEqual(false)


### PR DESCRIPTION
Follow up to #201

Improved the regex to match `exports["default"]` and `exports['default']`.
I found this pattern in `typesense-instantsearch-adapter`.
http://localhost:5173/typesense-instantsearch-adapter@2.9.0
